### PR TITLE
Fixed markup for the glossary section.

### DIFF
--- a/data_reuse/index.html
+++ b/data_reuse/index.html
@@ -185,6 +185,8 @@
             share without restrictions, the possible exception being a requirement of
             attribution.
           </p>
+        </section>
+        <section class="term">
           <h3>Metadata</h3>
           <p>
             Information that describes, explains, locates, or in some way makes it easier to
@@ -192,6 +194,8 @@
             a photograph may include the name of the photographer, when and where it was taken,
             as well as the type of camera and settings used to take the photograph.
           </p>
+        </section>
+        <section class="term">
           <h3>Licensing</h3>
           <p>
             A license gives explicit permissions for the use of something. This is particularly
@@ -201,6 +205,8 @@
             here: <a href="http://www.dcc.ac.uk/resources/how-guides/license-research-data">
             http://www.dcc.ac.uk/resources/how-guides/license-research-data</a>.
           </p>
+        </section>
+        <section class="term">
           <h3>Naming Conventions</h3>
           <p>
             These are a set of predefined rules for the naming and structure of folders, files,
@@ -209,6 +215,8 @@
             standard of data collection and management is being followed by all members of a
             team.
           </p>
+        </section>
+        <section class="term">
           <h3>Permanent Identifiers</h3>
           <p>
             A permanent identifier (or PID) is a set of numbers and/or characters, frequently


### PR DESCRIPTION
This fixes the Glossary section not spanning two columns as noticed by @stephwright in #17

The reason for the single-column layout notice earlier is that each term needs to be wrapped in a `<section class='term'></section>` tag, which wasn't the case. I'll update the template so that there are two terms, which will illustrate this more clearly.

@acabunoc R?
