### PR TITLE
Remove '?dl=1' from Transcription links to avoid forced download

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       </div>
 
       <div class="image">
-        <img src="http://i.imgur.com/CfugmWx.png" alt="mozwow" height="90" width="770"> 
+        <img src="http://i.imgur.com/CfugmWx.png" alt="mozwow" height="90" width="770">
       </div>
 
 
@@ -95,18 +95,18 @@
       </p>
 
       <ul>
-        <li>WOW-Berlin Introductions - <a href="https://www.dropbox.com/s/buhs7ng1b2t5bc7/WOW%20Berlin%202-5-16%20intros.txt?dl=1" target="_blank">transcription</a></li>
-        <li>WOW-Berlin Diversity Exercise - <a href="https://www.dropbox.com/s/y5a43tj4ihf7qaj/WOW%20Berlin%202-5-16%20Code%20of%20Conduct%20Activity.txt?dl=1" target="_blank">transcription</a></li>
-        <li>WOW-Berlin First Work Session Intro - <a href="https://www.dropbox.com/s/hot5dkk2tgfdukw/WOW%20Berlin%202-5-16%20First%20Work%20Session.txt?dl=1" target="_blank">transcription</a></li>
-        <li>Zannah - README + Project Communication - <a href="https://www.dropbox.com/s/wkwasgpvjoi8qee/WOW%20Berlin%202-5-16%20Zannah%20Talk.txt?dl=1" target="_blank">transcription</a></li>
-        <li>Abby - Roadmapping - <a href="https://www.dropbox.com/s/olg3r8cssklu7kp/WOW%20Berlin%202-5-16%20Abby%20Talk.txt?dl=1">transcription</a></li>
-        <li>Aurelia - Contribution Guidelines - <a href="https://www.dropbox.com/s/q7vcpgupgpoeuwp/WOW%20Berlin%202-5-16%20Aurelia%20Talk.txt?dl=1">transcription</a></li>
-        <li>Github Workshop - <a href="https://www.dropbox.com/s/d8b1xwnhsb20maz/WOW%20Berlin%202-5-16pm%20GitHub%20Demo.txt?dl=1">transcription</a></li>
-        <li>WOW-Berlin Closing Outro-Day 1 - <a href="https://www.dropbox.com/s/avlbqslps78fojo/WOW%20Berlin%202-5-16%20pm%20wrapup.txt?dl=1">transcription</a></li>
-        <li>Kaitlin - Code of Conduct - <a href="https://www.dropbox.com/s/grnkmi0z90u8wgl/WOW%20Berlin%202-6-16%20Starting%20Codes%20of%20Conduct.txt?dl=1">transcription</a></li>
-        <li>Arliss/Madeleine - Sprint + Event Planning - <a href="https://www.dropbox.com/s/lw826vz3m6j4lqq/WOW%20Berlin%202-6-16%20Sprints%20and%20Community%20Events.txt?dl=1">transcription</a></li>  
-        <li>Steph + Christie - Data Reuse Workshop - <a href="https://www.dropbox.com/s/w5x9u93vy5l30li/WOW%20Berlin%202-6-16%20pm%20work%20session.txt?dl=1">transcription</a></li>  
-        <li>Closing Session - <a href="https://www.dropbox.com/s/ql2354gmk7yd8m7/WOW%20Berlin%202-6-16pm%20closing%20session.txt?dl=1">transcription</a></li>  
+        <li>WOW-Berlin Introductions - <a href="https://www.dropbox.com/s/buhs7ng1b2t5bc7/WOW%20Berlin%202-5-16%20intros.txt" target="_blank">transcription</a></li>
+        <li>WOW-Berlin Diversity Exercise - <a href="https://www.dropbox.com/s/y5a43tj4ihf7qaj/WOW%20Berlin%202-5-16%20Code%20of%20Conduct%20Activity.txt" target="_blank">transcription</a></li>
+        <li>WOW-Berlin First Work Session Intro - <a href="https://www.dropbox.com/s/hot5dkk2tgfdukw/WOW%20Berlin%202-5-16%20First%20Work%20Session.txt" target="_blank">transcription</a></li>
+        <li>Zannah - README + Project Communication - <a href="https://www.dropbox.com/s/wkwasgpvjoi8qee/WOW%20Berlin%202-5-16%20Zannah%20Talk.txt" target="_blank">transcription</a></li>
+        <li>Abby - Roadmapping - <a href="https://www.dropbox.com/s/olg3r8cssklu7kp/WOW%20Berlin%202-5-16%20Abby%20Talk.txt">transcription</a></li>
+        <li>Aurelia - Contribution Guidelines - <a href="https://www.dropbox.com/s/q7vcpgupgpoeuwp/WOW%20Berlin%202-5-16%20Aurelia%20Talk.txt">transcription</a></li>
+        <li>Github Workshop - <a href="https://www.dropbox.com/s/d8b1xwnhsb20maz/WOW%20Berlin%202-5-16pm%20GitHub%20Demo.txt">transcription</a></li>
+        <li>WOW-Berlin Closing Outro-Day 1 - <a href="https://www.dropbox.com/s/avlbqslps78fojo/WOW%20Berlin%202-5-16%20pm%20wrapup.txt">transcription</a></li>
+        <li>Kaitlin - Code of Conduct - <a href="https://www.dropbox.com/s/grnkmi0z90u8wgl/WOW%20Berlin%202-6-16%20Starting%20Codes%20of%20Conduct.txt">transcription</a></li>
+        <li>Arliss/Madeleine - Sprint + Event Planning - <a href="https://www.dropbox.com/s/lw826vz3m6j4lqq/WOW%20Berlin%202-6-16%20Sprints%20and%20Community%20Events.txt">transcription</a></li>
+        <li>Steph + Christie - Data Reuse Workshop - <a href="https://www.dropbox.com/s/w5x9u93vy5l30li/WOW%20Berlin%202-6-16%20pm%20work%20session.txt">transcription</a></li>
+        <li>Closing Session - <a href="https://www.dropbox.com/s/ql2354gmk7yd8m7/WOW%20Berlin%202-6-16pm%20closing%20session.txt">transcription</a></li>
 
       </ul>
       <p>


### PR DESCRIPTION
The `?dl=1` at the end of the Dropbox URLs forces the user to download the files instead of opening them in the browser and giving the user choice. I've therefore removed these from all the relevant URLs.
